### PR TITLE
Improve PlayTools Info metadata fallback

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -565,9 +565,11 @@
 			);
 			inputFileListPaths = (
 			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/PlayTools.xcframework/ios-arm64/PlayTools.framework",
-			);
+                        inputPaths = (
+                                "$(SRCROOT)/Carthage/Build/PlayTools.xcframework/ios-arm64/PlayTools.framework",
+                                "$(SRCROOT)/Carthage/Build/Mac/PlayTools.framework",
+                                "$(SRCROOT)/Carthage/Build/PlayTools.framework",
+                        );
 			name = "Copy Carthage frameworks";
 			outputFileListPaths = (
 			);
@@ -576,7 +578,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/zsh;
-			shellScript = "set -euo pipefail\n\nif [ -x /usr/local/bin/carthage ]; then\n    carthage=/usr/local/bin/carthage\nelif [ -x /opt/homebrew/bin/carthage ]; then\n    carthage=/opt/homebrew/bin/carthage\nelif [ -x /opt/local/bin/carthage ]; then\n    carthage=/opt/local/bin/carthage\nelse\n    echo \"Cannot find carthage\"\n    exit 1\nfi\n\necho \"Codesigning PlayTools\"\n\n$carthage copy-frameworks\n\necho cp -rf ${SCRIPT_INPUT_FILE_0}/PlugIns/AKInterface.bundle ${SCRIPT_OUTPUT_FILE_0}/PlugIns/AKInterface.bundle\n\nrm -rf ${SCRIPT_OUTPUT_FILE_0}/PlugIns/AKInterface.bundle\ncp -rf ${SCRIPT_INPUT_FILE_0}/PlugIns/AKInterface.bundle ${SCRIPT_OUTPUT_FILE_0}/PlugIns/AKInterface.bundle\n\necho \"Normalizing PlayTools framework bundle layout\"\nFRAMEWORK=\"${SCRIPT_OUTPUT_FILE_0}\"\n\nif [ ! -d \"${FRAMEWORK}/Versions\" ]; then\n    mkdir -p \"${FRAMEWORK}/Versions/A\"\n\n    if [ -f \"${FRAMEWORK}/PlayTools\" ]; then\n        mv \"${FRAMEWORK}/PlayTools\" \"${FRAMEWORK}/Versions/A/PlayTools\"\n    fi\n\n    for dir in Modules Headers Resources PlugIns Frameworks; do\n        if [ -d \"${FRAMEWORK}/${dir}\" ]; then\n            mv \"${FRAMEWORK}/${dir}\" \"${FRAMEWORK}/Versions/A/${dir}\"\n        fi\n    done\n\n    if [ -f \"${FRAMEWORK}/Info.plist\" ]; then\n        mkdir -p \"${FRAMEWORK}/Versions/A/Resources\"\n        mv \"${FRAMEWORK}/Info.plist\" \"${FRAMEWORK}/Versions/A/Resources/Info.plist\"\n    fi\n\n    ln -sfn A \"${FRAMEWORK}/Versions/Current\"\n\n    if [ -f \"${FRAMEWORK}/Versions/A/PlayTools\" ]; then\n        ln -sfn \"Versions/Current/PlayTools\" \"${FRAMEWORK}/PlayTools\"\n    fi\n\n    for dir in Modules Headers Resources PlugIns Frameworks; do\n        if [ -d \"${FRAMEWORK}/Versions/A/${dir}\" ]; then\n            ln -sfn \"Versions/Current/${dir}\" \"${FRAMEWORK}/${dir}\"\n        fi\n    done\nfi\n\nrm -rf \"${FRAMEWORK}/_CodeSignature\"\n\necho \"Converting to maccatalyst\"\nvtool -set-build-version maccatalyst 11.0 14.0 -replace -output \"${SCRIPT_OUTPUT_FILE_0}/PlayTools\" \"${SCRIPT_OUTPUT_FILE_0}/PlayTools\"\n";
+			shellScript = "set -euo pipefail\n\nDESTINATION="${SCRIPT_OUTPUT_FILE_0}"\n\nCANDIDATES=(\n    "${SRCROOT}/Carthage/Build/PlayTools.xcframework/ios-arm64/PlayTools.framework"\n    "${SRCROOT}/Carthage/Build/Mac/PlayTools.framework"\n    "${SRCROOT}/Carthage/Build/PlayTools.framework"\n)\n\nSOURCE=""\nfor candidate in "${CANDIDATES[@]}"; do\n    if [ -d "$candidate" ]; then\n        SOURCE="$candidate"\n        break\n    fi\ndone\n\nif [ -z "${SOURCE}" ]; then\n    echo "Missing PlayTools framework. Checked:"\n    printf '  %s\\n' "${CANDIDATES[@]}"\n    exit 1\nfi\n\nINFO_SOURCE=""\nINFO_CANDIDATES=(\n    "${SOURCE}/Versions/Current/Resources/Info.plist"\n    "${SOURCE}/Resources/Info.plist"\n    "${SOURCE}/Info.plist"\n)\nfor info_candidate in "${INFO_CANDIDATES[@]}"; do\n    if [ -f "$info_candidate" ]; then\n        INFO_SOURCE="$info_candidate"\n        break\n    fi\ndone\n\nplist_value() {\n    local key="$1"\n    local default="$2"\n    local value="$default"\n\n    if [ -n "$INFO_SOURCE" ] && [ -f "$INFO_SOURCE" ] && [ -x /usr/libexec/PlistBuddy ]; then\n        if extracted=$(/usr/libexec/PlistBuddy -c "Print :$key" "$INFO_SOURCE" 2>/dev/null); then\n            if [ -n "$extracted" ]; then\n                value="$extracted"\n            fi\n        fi\n    fi\n\n    printf %s "$value"\n}\n\nBUNDLE_IDENTIFIER=$(plist_value CFBundleIdentifier io.playcover.PlayTools)\nBUNDLE_NAME=$(plist_value CFBundleName PlayTools)\nBUNDLE_EXECUTABLE=$(plist_value CFBundleExecutable PlayTools)\nBUNDLE_SHORT_VERSION=$(plist_value CFBundleShortVersionString 1.0)\nBUNDLE_VERSION=$(plist_value CFBundleVersion 1)\n\nrm -rf "${DESTINATION}"\nmkdir -p "${DESTINATION}"\n\necho "Copying PlayTools framework from ${SOURCE} into build products"\nif command -v rsync >/dev/null 2>&1; then\n    rsync -a "${SOURCE}/" "${DESTINATION}/"\nelse\n    cp -R "${SOURCE}/." "${DESTINATION}"\nfi\n\nif [ -d "${SOURCE}/PlugIns/AKInterface.bundle" ]; then\n    mkdir -p "${DESTINATION}/PlugIns"\n    rm -rf "${DESTINATION}/PlugIns/AKInterface.bundle"\n    cp -R "${SOURCE}/PlugIns/AKInterface.bundle" "${DESTINATION}/PlugIns/AKInterface.bundle"\nfi\n\necho "Normalizing PlayTools framework bundle layout"\nFRAMEWORK="${DESTINATION}"\n\nif [ ! -d "${FRAMEWORK}/Versions" ]; then\n    mkdir -p "${FRAMEWORK}/Versions/A"\n\n    if [ -f "${FRAMEWORK}/PlayTools" ]; then\n        mv "${FRAMEWORK}/PlayTools" "${FRAMEWORK}/Versions/A/PlayTools"\n    fi\n\n    for dir in Modules Headers Resources PlugIns Frameworks; do\n        if [ -d "${FRAMEWORK}/${dir}" ]; then\n            mv "${FRAMEWORK}/${dir}" "${FRAMEWORK}/Versions/A/${dir}"\n        fi\n    done\n\n    if [ -f "${FRAMEWORK}/Info.plist" ]; then\n        mkdir -p "${FRAMEWORK}/Versions/A/Resources"\n        mv "${FRAMEWORK}/Info.plist" "${FRAMEWORK}/Versions/A/Resources/Info.plist"\n    fi\n\n    ln -sfn A "${FRAMEWORK}/Versions/Current"\n\n    if [ -f "${FRAMEWORK}/Versions/A/PlayTools" ]; then\n        ln -sfn "Versions/Current/PlayTools" "${FRAMEWORK}/PlayTools"\n    fi\n\n    for dir in Modules Headers Resources PlugIns Frameworks; do\n        if [ -d "${FRAMEWORK}/Versions/A/${dir}" ]; then\n            ln -sfn "Versions/Current/${dir}" "${FRAMEWORK}/${dir}"\n        fi\n    done\nfi\n\nINFO_SYMLINK="${FRAMEWORK}/Info.plist"\nINFO_TARGET="${FRAMEWORK}/Versions/Current/Resources/Info.plist"\n\nif [ -f "${INFO_SYMLINK}" ] && [ ! -L "${INFO_SYMLINK}" ]; then\n    mkdir -p "${FRAMEWORK}/Versions/Current/Resources"\n    mv "${INFO_SYMLINK}" "${INFO_TARGET}"\nfi\n\nif [ ! -f "${INFO_TARGET}" ]; then\n    mkdir -p "${FRAMEWORK}/Versions/Current/Resources"\n    cat <<EOF > "${INFO_TARGET}"\n<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n    <key>CFBundleExecutable</key>\n    <string>${BUNDLE_EXECUTABLE}</string>\n    <key>CFBundleIdentifier</key>\n    <string>${BUNDLE_IDENTIFIER}</string>\n    <key>CFBundleName</key>\n    <string>${BUNDLE_NAME}</string>\n    <key>CFBundlePackageType</key>\n    <string>FMWK</string>\n    <key>CFBundleShortVersionString</key>\n    <string>${BUNDLE_SHORT_VERSION}</string>\n    <key>CFBundleVersion</key>\n    <string>${BUNDLE_VERSION}</string>\n</dict>\n</plist>\nEOF\nfi\n\nif command -v plutil >/dev/null 2>&1; then\n    plutil -replace CFBundlePackageType -string FMWK "${INFO_TARGET}"\n    plutil -replace CFBundleExecutable -string "${BUNDLE_EXECUTABLE}" "${INFO_TARGET}"\n    plutil -replace CFBundleName -string "${BUNDLE_NAME}" "${INFO_TARGET}"\n    plutil -replace CFBundleIdentifier -string "${BUNDLE_IDENTIFIER}" "${INFO_TARGET}"\n    plutil -replace CFBundleShortVersionString -string "${BUNDLE_SHORT_VERSION}" "${INFO_TARGET}"\n    plutil -replace CFBundleVersion -string "${BUNDLE_VERSION}" "${INFO_TARGET}"\nfi\n\nln -sfn "Versions/Current/Resources/Info.plist" "${INFO_SYMLINK}"\n\n\nrm -rf "${FRAMEWORK}/_CodeSignature"\n\nif [ -f "${DESTINATION}/PlayTools" ]; then\n    echo "Converting PlayTools binary to maccatalyst load commands"\n    vtool -set-build-version maccatalyst 11.0 14.0 -replace -output "${DESTINATION}/PlayTools" "${DESTINATION}/PlayTools"\nfi\n";
 		};
 		AAC28F222899A05B005057FB /* Codesign sparkle */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -595,8 +597,466 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nset -euo pipefail\n\nIDENTITY=${EXPANDED_CODE_SIGN_IDENTITY_NAME};\n# Apple Development: XIN LI (33X85HBRP6)\necho Signing identity $IDENTITY;\n\ncodesign --verbose --force --deep --sign \"$IDENTITY\" ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework/PlugIns/AKInterface.bundle;\ncodesign --verbose --force --deep --sign \"$IDENTITY\" ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework;\n\n# sign sparkle\nLOCATION=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework\";\necho Sparkle Signing location $LOCATION;\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Autoupdate\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Updater.app\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Downloader.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Installer.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION\";\n";
+
+                        shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nset -euo pipefail\n\nIDENTITY=${EXPANDED_CODE_SIGN_IDENTITY_NAME};\n# Apple Development: XIN LI (33X85HBRP6)\necho Signing identity $IDENTITY;\n\nPLAYTOOLS_FRAMEWORK=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework\";\n\nsign_bundle() {\n    bundle_path=\"$1\"\n\n    if [ ! -e \"$bundle_path\" ]; then\n        return\n    fi\n\n    if ! codesign --verbose --force --deep --sign \"$IDENTITY\" \"$bundle_path\"; then\n        if [ -d \"$bundle_path/Versions/Current\" ]; then\n            echo \"Retrying codesign for ${bundle_path} by signing the versioned directory\"\n            if codesign --verbose --force --deep --sign \"$IDENTITY\" \"$bundle_path/Versions/Current\"; then\n                codesign --verbose --force --deep --sign \"$IDENTITY\" \"$bundle_path\"\n            fi\n        fi\n    fi\n}\n\nsign_bundle \"${PLAYTOOLS_FRAMEWORK}/PlugIns/AKInterface.bundle\";\n\nif [ -d \"${PLAYTOOLS_FRAMEWORK}/Versions/Current\" ]; then\n    sign_bundle \"${PLAYTOOLS_FRAMEWORK}/Versions/Current\";\nfi;\n\nsign_bundle \"${PLAYTOOLS_FRAMEWORK}\";\n\n# sign sparkle\nLOCATION=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework\";\necho Sparkle Signing location $LOCATION;\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Autoupdate\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Updater.app\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Downloader.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Installer.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION\";\n";
+                };
+		AAE8809C287ACA4900FBB23C /* Carthage Bootstrap */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Carthage Bootstrap";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -z \"$FASTLANE\" ]]; then\n    set -euo pipefail\n    echo \"Bootstraping carthage\"\n\n    if [ -x /usr/local/bin/carthage ]; then\n        carthage=/usr/local/bin/carthage\n    elif [ -x /opt/homebrew/bin/carthage ]; then\n        carthage=/opt/homebrew/bin/carthage\n    elif [ -x /opt/local/bin/carthage ]; then\n        carthage=/opt/local/bin/carthage\n    else\n        echo \"Cannot find carthage\"\n        exit 1\n    fi\n\n    $carthage update --cache-builds --use-xcframeworks\nfi\n";
 		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8783CFF326B8C52D00171041 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6E66B0D3289F5A010099B907 /* StoreAppView.swift in Sources */,
+				6E66B0D528A0039D0099B907 /* ToastView.swift in Sources */,
+				92ECD8A3274E75CD00DB7AC6 /* Installer.swift in Sources */,
+				B6825C3528F3D23600E3015A /* InstallSettings.swift in Sources */,
+				92EE06DE274EC09F002C907B /* Entitlements.swift in Sources */,
+				92ECD8A5274E763700DB7AC6 /* IPA.swift in Sources */,
+				365AFB0828847B75008B3542 /* Sparkle.swift in Sources */,
+				92B4D38F2737CF3D0001D7BB /* PlayTools.swift in Sources */,
+				3665EF8928832400007CF915 /* PlayCoverSettingsView.swift in Sources */,
+				9280871B2824A8D20034C510 /* SoundDeviceService.swift in Sources */,
+				34775E752D493B59001586C2 /* CachedAsyncImageWrapper.swift in Sources */,
+				A25930F42C49E2BC0006C91C /* PlayAppVM.swift in Sources */,
+				92ECD8AE274E787200DB7AC6 /* AppInfo.swift in Sources */,
+				6E250971297F5281004D754C /* SigningSetupView.swift in Sources */,
+				928C01D9272E162C007EB2DF /* InstallVM.swift in Sources */,
+				6E550A8B29BA507200EFC15C /* Macho.swift in Sources */,
+				6E25096F297F5032004D754C /* FileExtensions.swift in Sources */,
+				53F4D2A026C43C690020167C /* Log.swift in Sources */,
+				B67C1A132AE80A7400F396CC /* StoreAppVM.swift in Sources */,
+				B6603E1128E206A300DEFA3F /* UninstallSettings.swift in Sources */,
+				92A8AAC9275EFEA800D89B50 /* SystemConfig.swift in Sources */,
+				6E66B0C9289F52800099B907 /* IPALibraryView.swift in Sources */,
+				B1084E1F28AA80F400E399FA /* AppSettingsVM.swift in Sources */,
+				6E7CA16728B4EEAE00216CD8 /* Keymapping.swift in Sources */,
+				6ED6ACA428A949A30040D234 /* AppSettingsView.swift in Sources */,
+				92EE06DA274EB009002C907B /* PlayApp.swift in Sources */,
+				53F50C4926E3CA42007AD2D3 /* AppLibraryView.swift in Sources */,
+				6E66B0D1289F57B00099B907 /* Documentation.docc in Sources */,
+				53F3802826EB6F6B00D6B525 /* NotifyService.swift in Sources */,
+				6E5C68BA289865C8008EC11B /* MainView.swift in Sources */,
+				B1419FB628BA82EE000CB69F /* DiscordActivity.swift in Sources */,
+				6E66B0BF289DE6240099B907 /* StoreVM.swift in Sources */,
+				B6603E1328E2257800DEFA3F /* Uninstaller.swift in Sources */,
+				B6ABDA2A2971EEF700A46E80 /* ProgressVM.swift in Sources */,
+				AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */,
+				6ECB1D0E29798DFA00CD92AA /* DataExtensions.swift in Sources */,
+				6E66B0D928A135360099B907 /* ToastVM.swift in Sources */,
+				92EE06D0274EA433002C907B /* BaseApp.swift in Sources */,
+				ABBC85B92B7C5CBA00DCF223 /* ModifierKeyObserver.swift in Sources */,
+				92F8500A27675124005CE6BE /* AppIntegrity.swift in Sources */,
+				B44B40372C1E315600CE2A3E /* GoogleDrive.swift in Sources */,
+				68E48B97295704A600C39879 /* Downloader.swift in Sources */,
+				36B26B97288C724600859EFD /* UpdateSettings.swift in Sources */,
+				ABDAD80A29893EA300DC164F /* KeyCoverSettings.swift in Sources */,
+				8783CFFB26B8C52D00171041 /* PlayCoverApp.swift in Sources */,
+				AB6F21EB299B7FA20078ADEC /* URLHandler.swift in Sources */,
+				6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */,
+				5314D1EE26C402EC00A0A727 /* Shell.swift in Sources */,
+				6E7CA16528B4D02900216CD8 /* ITunesResponse.swift in Sources */,
+				ABDAD80C298A1E3E00DC164F /* KeyCoverViews.swift in Sources */,
+				6EF893D528F34CD1004AB6D9 /* NetworkVM.swift in Sources */,
+				8783D00B26B8C9E600171041 /* URLExtensions.swift in Sources */,
+				6EB4B57428C93E0600630890 /* LegacySettings.swift in Sources */,
+				ABED59832887A32F004D782B /* MenuBarView.swift in Sources */,
+				B6AB53C929232B4F00039B2E /* KeyCodeNames.swift in Sources */,
+				92EE06D4274EA604002C907B /* PlayAppView.swift in Sources */,
+				B67C1A112AE8091F00F396CC /* StoreInfoAppView.swift in Sources */,
+				B17FD04728C7B0D900B1D4CA /* AssetsExtractor.swift in Sources */,
+				ABDAD80629893CF900DC164F /* KeyCoverSetupViews.swift in Sources */,
+				6888981729F9158700105D9C /* IPASourceView.swift in Sources */,
+				6EE8265028E8AB2B003935BC /* DownloadVM.swift in Sources */,
+				AB00EB5229A7BF17006F3225 /* KeyCover.swift in Sources */,
+				68E48B9C295709C000C39879 /* Cacher.swift in Sources */,
+				53D9DAF326C1849D0071959E /* PlayCoverError.swift in Sources */,
+				9286D296273A7E4200958DD3 /* AppSettings.swift in Sources */,
+				B68FD80D2ACB642100683778 /* PlayAppExtensions.swift in Sources */,
+				9272F19E273B74C800DFBEF1 /* AppsVM.swift in Sources */,
+				923421F7275F40300030CD7D /* AppContainer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		532644E026E79E56002EA34D /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				532644E126E79E5C002EA34D /* en */,
+				532644E226E7D9C4002EA34D /* de */,
+				532644E326E80DD0002EA34D /* zh-Hans */,
+				532644E426E80E1A002EA34D /* ru */,
+				532644E526E80E6B002EA34D /* id */,
+				531D717926E8313100F4A7AB /* es */,
+				53F3802526EB6CEA00D6B525 /* ja */,
+				53E3311126F574B600217197 /* ko */,
+				8FBBE76B2826709500F4FE9F /* fr */,
+				ABF0BA1A285F9ED200FC5259 /* vi */,
+				6EC228A028B14A0600D7D73A /* zh-Hant */,
+				81C2786C28D4A5A300E208D7 /* pt-br */,
+				6854C5E528D53C9500CE28A0 /* fa */,
+				6E692F1C290B34890090D9EC /* tr */,
+				6E692F1D290B349F0090D9EC /* ro */,
+				68C79E67296741580041DBC9 /* hi */,
+				6EA4A34B29B61CE9005F4679 /* da */,
+				B490E8692C0D0E8A004383FA /* it */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		8783D00626B8C52E00171041 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = arm64;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = x86_64;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = NO;
+				RUN_DOCUMENTATION_COMPILER = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		8783D00926B8C52E00171041 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				BUNDLE_ID_SUFFIX = "";
+				CODE_SIGN_ENTITLEMENTS = PlayCover/PlayCoverRelease.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 856;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "PlayCover/Preview\\ Content";
+				DEVELOPMENT_TEAM = 792V9HMJW3;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				EXCLUDED_ARCHS = x86_64;
+				INFOPLIST_FILE = PlayCover/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 3.1.0;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = io.playcover.PlayCover;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match Direct io.playcover.PlayCover macos";
+				RUN_DOCUMENTATION_COMPILER = NO;
+				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
+				SWIFT_OBJC_BRIDGING_HEADER = "./PlayCover/PlayCover-Bridging-Header.h";
+				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = "./PlayCover/PlayCover-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
+			};
+			name = Release;
+		};
+		9BFBDA6728C95BA500252EB7 /* Nightly */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = arm64;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = x86_64;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = NO;
+				RUN_DOCUMENTATION_COMPILER = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Nightly;
+		};
+		9BFBDA6828C95BA500252EB7 /* Nightly */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				BUNDLE_ID_SUFFIX = .dev;
+				CODE_SIGN_ENTITLEMENTS = PlayCover/PlayCoverRelease.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 856;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "PlayCover/Preview\\ Content";
+				DEVELOPMENT_TEAM = 792V9HMJW3;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				EXCLUDED_ARCHS = x86_64;
+				INFOPLIST_FILE = PlayCover/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 3.1.0;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = io.playcover.PlayCover;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match Direct io.playcover.PlayCover macos";
+				RUN_DOCUMENTATION_COMPILER = NO;
+				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
+				SWIFT_OBJC_BRIDGING_HEADER = "./PlayCover/PlayCover-Bridging-Header.h";
+				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = "./PlayCover/PlayCover-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
+			};
+			name = Nightly;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8783CFF226B8C52D00171041 /* Build configuration list for PBXProject "PlayCover" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8783D00626B8C52E00171041 /* Release */,
+				9BFBDA6728C95BA500252EB7 /* Nightly */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8783D00726B8C52E00171041 /* Build configuration list for PBXNativeTarget "PlayCover" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8783D00926B8C52E00171041 /* Release */,
+				9BFBDA6828C95BA500252EB7 /* Nightly */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+		68E48B932957046D00C39879 /* XCRemoteSwiftPackageReference "download-manager" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/shapedbyiris/download-manager.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
+		68E48B98295708C800C39879 /* XCRemoteSwiftPackageReference "inject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/paradiseduo/inject";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+		68E48B9D29570A0400C39879 /* XCRemoteSwiftPackageReference "DataCache" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huynguyencong/DataCache";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
+		68E48BA029570A2B00C39879 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/bullinnyc/CachedAsyncImage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.0;
+			};
+		};
+		AA818CB3287ABEC3000BEE9D /* XCRemoteSwiftPackageReference "Yams" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jpsim/Yams.git";
+			requirement = {
+				kind = versionRange;
+				maximumVersion = 6.0.0;
+				minimumVersion = 5.0.0;
+			};
+		};
+		B44E8CD12C31C50200542038 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/PlayCover/SwiftSoup";
+			requirement = {
+				kind = revision;
+				revision = 6d808c0522471d9f8892c85601164ed5b462f8c0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		365AFB0528847B2E008B3542 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+		68E48B942957046D00C39879 /* DownloadManager */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68E48B932957046D00C39879 /* XCRemoteSwiftPackageReference "download-manager" */;
+			productName = DownloadManager;
+		};
+		68E48B99295708C800C39879 /* Injection */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68E48B98295708C800C39879 /* XCRemoteSwiftPackageReference "inject" */;
+			productName = Injection;
+		};
+		68E48B9E29570A0400C39879 /* DataCache */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68E48B9D29570A0400C39879 /* XCRemoteSwiftPackageReference "DataCache" */;
+			productName = DataCache;
+		};
+		68E48BA129570A2B00C39879 /* CachedAsyncImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68E48BA029570A2B00C39879 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */;
+			productName = CachedAsyncImage;
+		};
+		AA818CB4287ABEC3000BEE9D /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA818CB3287ABEC3000BEE9D /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
+		};
+		B44E8CD22C31C50200542038 /* SwiftSoup */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B44E8CD12C31C50200542038 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
+			productName = SwiftSoup;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 8783CFEF26B8C52D00171041 /* Project object */;
+}		};
 		AAE8809C287ACA4900FBB23C /* Carthage Bootstrap */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;


### PR DESCRIPTION
## Summary
- capture Info.plist metadata from the located PlayTools bundle and reuse those values when normalizing the framework copy
- generate the fallback Info.plist with the captured identifier, name, executable, and version details before reapplying the FMWK package type overrides

## Testing
- not run (requires macOS/Xcode)

------
https://chatgpt.com/codex/tasks/task_e_68cb96ca33c48323b7dc9deda1d5c6f4