### PR TITLE
Fix PlayTools integration scripts

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -577,9 +577,9 @@
 			);
 			inputFileListPaths = (
 			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/PlayTools.xcframework/ios-arm64/PlayTools.framework",
-			);
+                        inputPaths = (
+                                "$(SRCROOT)/Carthage/Build/PlayTools.xcframework",
+                        );
 			name = "Copy Carthage frameworks";
 			outputFileListPaths = (
 			);
@@ -587,8 +587,8 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/PlayTools.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/zsh;
-			shellScript = "set -euo pipefail\n\nif [ -x /usr/local/bin/carthage ]; then\n    carthage=/usr/local/bin/carthage\nelif [ -x /opt/homebrew/bin/carthage ]; then\n    carthage=/opt/homebrew/bin/carthage\nelif [ -x /opt/local/bin/carthage ]; then\n    carthage=/opt/local/bin/carthage\nelse\n    echo \"Cannot find carthage\"\n    exit 1\nfi\n\necho \"Codesigning PlayTools\"\n\n$carthage copy-frameworks\n\necho cp -rf ${SCRIPT_INPUT_FILE_0}/PlugIns/AKInterface.bundle ${SCRIPT_OUTPUT_FILE_0}/PlugIns/AKInterface.bundle\n\nrm -rf ${SCRIPT_OUTPUT_FILE_0}/PlugIns/AKInterface.bundle\ncp -rf ${SCRIPT_INPUT_FILE_0}/PlugIns/AKInterface.bundle ${SCRIPT_OUTPUT_FILE_0}/PlugIns/AKInterface.bundle\n\necho \"Converting to maccatalyst\"\nvtool \\\n    -set-build-version maccatalyst 11.0 14.0 \\\n    -replace -output \\\n    \"${SCRIPT_OUTPUT_FILE_0}/PlayTools\" \\\n    \"${SCRIPT_OUTPUT_FILE_0}/PlayTools\"\n";
+                        shellPath = /bin/sh;
+                        shellScript = "set -euo pipefail\n\nxcframework=\"${SCRIPT_INPUT_FILE_0}\"\nframework_dest=\"${SCRIPT_OUTPUT_FILE_0}\"\n\nif [ ! -d \"$xcframework\" ]; then\n    echo \"error: Missing PlayTools xcframework at $xcframework\"\n    exit 1\nfi\n\nframework_source=$( /usr/bin/find \"$xcframework\" -type d -path '*ios-arm64_x86_64-maccatalyst/PlayTools.framework' -maxdepth 3 -print -quit )\nif [ -z \"$framework_source\" ]; then\n    framework_source=$( /usr/bin/find \"$xcframework\" -type d -path '*ios-arm64/PlayTools.framework' -maxdepth 3 -print -quit )\nfi\n\nif [ -z \"$framework_source\" ]; then\n    echo \"error: Unable to locate PlayTools.framework within $xcframework\"\n    exit 1\nfi\n\necho \"Copying PlayTools from $framework_source to $framework_dest\"\nrm -rf \"$framework_dest\"\nmkdir -p \"$framework_dest\"\nditto \"$framework_source\" \"$framework_dest\"\n\nplugin_source=\"$framework_source/PlugIns/AKInterface.bundle\"\nplugin_dest=\"$framework_dest/PlugIns/AKInterface.bundle\"\nif [ -d \"$plugin_source\" ]; then\n    echo \"Embedding AKInterface bundle\"\n    rm -rf \"$plugin_dest\"\n    mkdir -p \"${plugin_dest%/*}\"\n    ditto \"$plugin_source\" \"$plugin_dest\"\nfi\n\nif [ -x \"/usr/bin/vtool\" ]; then\n    binary=\"$framework_dest/PlayTools\"\n    if [ ! -f \"$binary\" ]; then\n        binary=\"$framework_dest/Versions/A/PlayTools\"\n    fi\n    if [ -f \"$binary\" ]; then\n        echo \"Converting PlayTools binary to Mac Catalyst platform\"\n        /usr/bin/vtool -set-build-version maccatalyst 11.0 14.0 -replace -output \"$binary\" \"$binary\"\n    fi\nfi\n";
 		};
 		AAC28F222899A05B005057FB /* Codesign sparkle */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -607,7 +607,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nset -euo pipefail\n\nIDENTITY=${EXPANDED_CODE_SIGN_IDENTITY_NAME};\n# Apple Development: XIN LI (33X85HBRP6)\necho Signing identity $IDENTITY;\n\ncodesign --verbose --force --deep --sign \"$IDENTITY\" ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework/PlugIns/AKInterface.bundle;\ncodesign --verbose --force --deep --sign \"$IDENTITY\" ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework;\n\n# sign sparkle\nLOCATION=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework\";\necho Sparkle Signing location $LOCATION;\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Autoupdate\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Updater.app\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Downloader.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Installer.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION\";\n";
+                        shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nset -euo pipefail\n\nif [[ \"${CODE_SIGNING_ALLOWED:-YES}\" != \"YES\" ]]; then\n    echo \"Code signing disabled for this build configuration, skipping manual signing steps\"\n    exit 0\nfi\n\nIDENTITY=${EXPANDED_CODE_SIGN_IDENTITY_NAME};\n# Apple Development: XIN LI (33X85HBRP6)\necho Signing identity $IDENTITY;\n\ncodesign --verbose --force --sign \"$IDENTITY\" ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework/PlugIns/AKInterface.bundle;\ncodesign --verbose --force --sign \"$IDENTITY\" ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayTools.framework;\n\n# sign sparkle\nLOCATION=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sparkle.framework\";\necho Sparkle Signing location $LOCATION;\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Autoupdate\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/Updater.app\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Downloader.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION/Versions/B/XPCServices/Installer.xpc\";\ncodesign -f -o runtime -s \"$IDENTITY\" \"$LOCATION\";\n";
 		};
 		AAE8809C287ACA4900FBB23C /* Carthage Bootstrap */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary
- copy the PlayTools xcframework slice manually instead of relying on Carthage scripts
- embed the AKInterface bundle and retag the PlayTools binary for Mac Catalyst builds
- guard the manual codesign script so it respects CODE_SIGNING_ALLOWED and resigns PlayTools without using --deep

## Testing
- not run (macOS-only tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf89e825a08323b590025043154652